### PR TITLE
[Issue 46] Caching of Archives appears to be broken

### DIFF
--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -82,13 +82,13 @@ func (c *cache) CopyArchives(uuidSafe string) (archives []OnlineGetArchive, err 
 
 func (c *cache) InsertSafe(uuid string, safe OnlineGetSafe) {
 	c.Lock()
-	if _, ok := c.safes[uuid]; !ok {
+	if _, found := c.safes[uuid]; !found {
 		c.safes[uuid] = cacheSafe{
 			Safe:    safe,
 			Archive: make(map[string]OnlineGetArchive),
 		}
+		c.Save()
 	}
-	c.Save()
 	c.Unlock()
 }
 

--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -82,9 +82,11 @@ func (c *cache) CopyArchives(uuidSafe string) (archives []OnlineGetArchive, err 
 
 func (c *cache) InsertSafe(uuid string, safe OnlineGetSafe) {
 	c.Lock()
-	c.safes[uuid] = cacheSafe{
-		Safe:    safe,
-		Archive: make(map[string]OnlineGetArchive),
+	if _, ok := c.safes[uuid]; !ok {
+		c.safes[uuid] = cacheSafe{
+			Safe:    safe,
+			Archive: make(map[string]OnlineGetArchive),
+		}
 	}
 	c.Save()
 	c.Unlock()


### PR DESCRIPTION
Issue in the cache, when I try to remove an archive, I have a error saying "Archive not found"
The problem is the cache creates a new map for each "safe", so the previous one is lost