### PR TITLE
list unix timestamp of archive to permit easy old archive deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,15 @@ Options:
   -h, --help=false      Print usage
   -p, --platform=false  Show the platforms
   -q, --quiet=false     Only display UUIDs
+  -t, --ts=false        Show unix timestamp of archives (to script deletion for instance)
 
 Examples:
         $ c14 ls
         $ c14 ls -a
+        $ c14 ls -t
+
+        archives older than one week
+        $ c14 ls -t | awk '$NF < '$(date -d '1 week ago' +%s)' { print }'
 ```
 
 #### `c14 help`

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// VERSION represents the version of c14
-	VERSION = "v0.4"
+	VERSION = "v0.4.1"
 	// GITCOMMIT is overlaoded by the Makefile
 	GITCOMMIT = "commit"
 	// UserAgent represents the user-agent used for the API calls


### PR DESCRIPTION
Hi
the idea is to permit to delete old archives with a script filtering like this

basic listing
```
./c14 ls -t
NAME         STATUS              UUID                            ts
test1        active              aaaaaaa-e8f5-4497-b343-xxxxxx   1542880891
test2        active              aaaaaaa-86e0-4b64-9905-xxxxxx   1542812436
```

list archives, filtering older than one week
 ```
$ c14 ls -t | awk '$NF < '$(date -d '1 week ago' +%s)' { print }'
test_archive1      active              aaaaaa-ed8b-4c21-89c1-xxxxxxx   1542211353
test_archive2      active              aaaaaa-8d25-48da-bb67-xxxxxxx   1542211325
```

allowing one to remove old unused archives