### PR TITLE
Add GitHub Action

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,30 @@
+name: Go
+
+on: push
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.4
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v ./cmd/c14


### PR DESCRIPTION
Basically runs `go build -v ./cmd/c14`, make sure the project compiles.

Example: https://github.com/scaleway/c14-cli/runs/675758564

---

Based on https://github.com/scaleway/c14-cli/pull/70 so needs to be rebased on `master` it's merged. **Ignore the first two commits for now.**